### PR TITLE
Set default runs-on value globally

### DIFF
--- a/.github/workflows/cancel_job.yml
+++ b/.github/workflows/cancel_job.yml
@@ -10,11 +10,11 @@ on:
       runs_on:
         required: false
         type: string
-        default: docker
+        default: magma-runner-set
 
 jobs:
   cancel_job:
-    runs-on: docker-apps
+    runs-on: ${{ inputs.runs_on }}
     env:
       REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
       REMOTE_USER: ${{ secrets.REMOTE_USER }}

--- a/.github/workflows/enhanced_launch_job.yml
+++ b/.github/workflows/enhanced_launch_job.yml
@@ -6,7 +6,7 @@ on:
       runs_on:
         required: false
         type: string
-        default: docker
+        default: magma-runner-set
       enable_tunnel:
         required: false
         type: boolean

--- a/.github/workflows/launch_job.yml
+++ b/.github/workflows/launch_job.yml
@@ -6,7 +6,7 @@ on:
       runs_on:
         required: false
         type: string
-        default: docker
+        default: magma-runner-set
 
       job_path:
         required: false

--- a/.github/workflows/test_action_addons.yml
+++ b/.github/workflows/test_action_addons.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-action-addons:
-    runs-on: docker
+    runs-on: magma-runner-set
     steps:
       - uses: actions/checkout@v4
       - uses: ./addons


### PR DESCRIPTION
Now that runners are running in Kubernetes with actions-runners-controller, i have set by default the `magma-runner-set` runners label