### PR TITLE
Add nodejs to dockerfile

### DIFF
--- a/actions-runner-controller/runner/Dockerfile
+++ b/actions-runner-controller/runner/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/actions/actions-runner:2.317.0
 USER root
 
 RUN apt-get update && apt-get install -y \
+   curl \
    openssh-client \
    rsync \
    python-is-python3 \
@@ -11,7 +12,12 @@ RUN apt-get update && apt-get install -y \
 
 USER runner
 
-ENV PATH "$PATH:/home/runner/.local/bin"
+#Install node
+RUN curl -sS https://webi.sh/node@lts | sh
+ENV PATH "$PATH:/home/runner/.local/opt/node/bin"
 
+# Install python dependencies
 RUN python3 -m pip install --upgrade pip
 RUN pip install --user hpc-rocket==0.6.1 mlflow==2.14.1 sysrsync==1.1.1 python-dotenv==1.0.1 --no-cache-dir
+
+ENV PATH "$PATH:/home/runner/.local/bin"

--- a/actions-runner-controller/runner/Dockerfile
+++ b/actions-runner-controller/runner/Dockerfile
@@ -14,10 +14,12 @@ USER runner
 
 #Install node
 RUN curl -sS https://webi.sh/node@lts | sh
+RUN rm -rf /home/runner/Downloads/webi
+
 ENV PATH "$PATH:/home/runner/.local/opt/node/bin"
+ENV PATH "$PATH:/home/runner/.local/bin"
 
 # Install python dependencies
 RUN python3 -m pip install --upgrade pip
 RUN pip install --user hpc-rocket==0.6.1 mlflow==2.14.1 sysrsync==1.1.1 python-dotenv==1.0.1 --no-cache-dir
 
-ENV PATH "$PATH:/home/runner/.local/bin"


### PR DESCRIPTION
We need nodejs inside of the runner image in case we launch the jobs from local with act.
In order to avoid having multiple images we decide that we going to install nodejs in the same image even if this means increasing the runner image size by 100MB.
