### PR TITLE
Update actions to support Node 24

### DIFF
--- a/.github/workflows/actions-runner-docker-image.yml
+++ b/.github/workflows/actions-runner-docker-image.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/cancel_job.yml
+++ b/.github/workflows/cancel_job.yml
@@ -21,7 +21,7 @@ jobs:
       REMOTE_GROUP: ${{ secrets.REMOTE_GROUP }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # - name: Set up Python
       #   # This is the version of the action for setting up Python, not the Python version.
@@ -31,7 +31,7 @@ jobs:
       #     python-version: '3.12'
       #     # Optional - x64 or x86 architecture, defaults to x64
       #     architecture: 'x64'
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/docker2singularity.yml
+++ b/.github/workflows/docker2singularity.yml
@@ -18,9 +18,9 @@ jobs:
         run: echo "JOB_SINGULARITY_IMAGE=$(echo ${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}.sif | awk '{print tolower($0)}')" >> $GITHUB_ENV
 
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{secrets.SSH_PRIVATE_KEY}}
 

--- a/.github/workflows/docker2tar.yml
+++ b/.github/workflows/docker2tar.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 43200
     runs-on: ${{ inputs.runs_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Remove docker build cache
         if: always()
         run: | 

--- a/.github/workflows/docker_to_hub.yml
+++ b/.github/workflows/docker_to_hub.yml
@@ -69,7 +69,7 @@ jobs:
       image_ref: ${{ steps.prep.outputs.full_image }}:${{ steps.prep.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # For PRs, checkout the head branch

--- a/.github/workflows/install_requirements_online.yml
+++ b/.github/workflows/install_requirements_online.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 43200
     runs-on: ${{ inputs.runs_on }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: langtech-bsc/magma/actions/remote_job@main
         with:
           job: 'install-online'

--- a/.github/workflows/launch_job.yml
+++ b/.github/workflows/launch_job.yml
@@ -179,7 +179,7 @@ jobs:
       GPFS_HARNESS_EVAL_SINGULARITY: ${{ vars.GPFS_SINGULARITY_IMAGE_REGISTRY_PATH }}/${{ inputs.harness_eval_singularity }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: langtech-bsc/magma/actions/set_secrets_to_env_action@main
         with:
@@ -194,7 +194,7 @@ jobs:
           json: ${{ toJson(vars) }}
           name: 'secret'
 
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
   

--- a/.github/workflows/pre_job_per_branch.yml
+++ b/.github/workflows/pre_job_per_branch.yml
@@ -145,11 +145,11 @@ jobs:
           echo "job_name=${JOB_REPO_NAME}-${JOB_BRANCH}" >> $GITHUB_OUTPUT
           echo "job_path=${JOB_REPO_NAME}/${JOB_BRANCH}" >> $GITHUB_OUTPUT
 
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: check if job exists
         id: check_job
@@ -171,7 +171,7 @@ jobs:
             exit 1
 
 
-      - uses: actions-tools/yaml-outputs@8a3d95c649e970fbe0fb68b11e21a64a9b7bb1b0
+      - uses: actions-tools/yaml-outputs@v2
         id: yaml
         with:
           export-env-variables: false

--- a/.github/workflows/test_action_addons.yml
+++ b/.github/workflows/test_action_addons.yml
@@ -8,7 +8,7 @@ jobs:
   test-action-addons:
     runs-on: magma-runner-set
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: langtech-bsc/magma/actions/addons
         with:
             file: "src/launch.sh"

--- a/.github/workflows/test_action_addons.yml
+++ b/.github/workflows/test_action_addons.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: magma-runner-set
     steps:
       - uses: actions/checkout@v6
-      - uses: langtech-bsc/magma/actions/addons
+      - uses: langtech-bsc/magma/actions/addons@main
         with:
             file: "src/launch.sh"
             jupyter: true


### PR DESCRIPTION
This PR updates GitHub Actions in our workflows to versions that support Node.js 24, addressing deprecation warnings.
- actions/checkout updated to v6
- webfactory/ssh-agent updated to v0.10.0
- actions-tools/yaml-outputs updated to v2